### PR TITLE
Both space and EOF after dot can terminate a clause

### DIFF
--- a/src/trealla.c
+++ b/src/trealla.c
@@ -605,10 +605,9 @@ char *trealla_readline(FILE *fp)
 			{
 				if (block == line)
 				{
-					*dst++ = '\n';
-					*dst = '\0';
+					free(line);
+					line = NULL;
 				}
-
 				return line;
 			}
 
@@ -628,14 +627,15 @@ char *trealla_readline(FILE *fp)
 			{
 				int ch2 = fgetc(fp);
 
-				if (ch2 != EOF)
-					ungetc(ch2, fp);
-
-				if (isspace(ch2))
+				if (ch2 == EOF || isspace(ch2))
 				{
 					*dst = '\0';
 					//printf("*** GOT2 (%d): '%s'\n", (int)(dst-line), line);
 					return line;
+				}
+				else
+				{
+					ungetc(ch2, fp);
 				}
 			}
 


### PR DESCRIPTION
Redo fix for #58, as current fix will cause problem #61.