### PR TITLE
Set toplevel compound term as BARE

### DIFF
--- a/src/trealla.c
+++ b/src/trealla.c
@@ -1950,6 +1950,7 @@ const char *lexer_parse(lexer *self, node *term, const char *src, char **line)
 		if (!self->r)
 		{
 			self->r = term = make_structure();
+			term->flags |= FLAG_BARE;
 			self->term = NULL;
 			self->vars = self->anons = 0;
 			self->fact = 1;


### PR DESCRIPTION
Try to fix #13, but I'm not sure if I get the idea of `FLAG_BARE` correctly, is that means:

* `a, b` or `(a, b)` are bare compound terms, and
* `a(b)` is not?

BTW, error message of test case for issue #48 will affect by this change, I think that is a separate issue, so I'll investigate later.