### PR TITLE
Include stddef.h, which is needed by offsetof and size_t

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -1,6 +1,7 @@
 #ifndef INTERNAL_H
 #define INTERNAL_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 


### PR DESCRIPTION
This is a minor fix, as `offsetof` and `size_t` is used in `internal.h`, I think `<stddef.h>` should be included.

Have long time no write C code, but trying to write some BIF extensions now.