### PR TITLE
Add date and time prediates wrapper for POSIX interface

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,7 @@ OBJECTS_ISO = src/trealla.o src/parser.o src/bifs_iso.o src/jela.o \
 
 OBJECTS_ALL = $(OBJECTS_ISO) src/base64.o src/bifs_sys.o src/bifs_http.o \
 			src/jsonq.o src/bifs_net.o src/bifs_proc.o \
+			src/bifs_posix.o \
 			src/network.o src/thread.o src/uncle.o \
 			src/uuid.o src/xmlq.o src/bifs_dbs.o src/library.o \
 			src/auth.o src/blog.o src/dict.o src/lists.o \
@@ -109,6 +110,8 @@ src/bifs_proc.o: src/bifs_proc.c src/trealla.h src/bifs.h src/internal.h \
 src/bifs_sys.o: src/bifs_sys.c src/trealla.h src/base64.h src/bifs.h \
  src/internal.h src/skiplist.h src/skipbuck.h src/list.h src/network.h \
  src/thread.h src/utf8.h src/jela.h src/jsonq.h src/uuid.h src/xmlq.h
+src/bifs_posix.o: src/bifs_posix.c src/trealla.h src/bifs.h src/internal.h \
+ src/skiplist.h src/skipbuck.h src/list.h src/utf8.h src/jela.h
 src/daemon.o: src/daemon.c src/daemon.h
 src/history.o: src/history.c src/history.h src/utf8.h
 src/jela.o: src/jela.c src/trealla.h src/bifs.h src/internal.h src/skiplist.h \

--- a/src/bifs.h
+++ b/src/bifs.h
@@ -595,6 +595,7 @@ extern void bifs_load_dbs(void);
 extern void bifs_load_http(void);
 extern void bifs_load_ws(void);
 extern void bifs_load_stomp(void);
+extern void bifs_load_posix(void);
 #endif
 
 extern int bif_iso_true(tpl_query *q);

--- a/src/bifs_posix.c
+++ b/src/bifs_posix.c
@@ -1,0 +1,211 @@
+#define _XOPEN_SOURCE
+#include <time.h>
+
+#include "trealla.h"
+
+#include "bifs.h"
+#include "jela.h"
+
+static int bif_posix_format_time_3(tpl_query *q)
+{
+	node *args = get_args(q);
+	node *term1 = get_atom(term1);
+	node *term2 = get_compound(term2);
+	node *term3 = get_var(term3);
+
+	if (strcmp(term_functor(term2), "time")) {
+		return 0;
+	}
+
+	const char *format = VAL_S(term1);
+	size_t length = strlen(format);
+
+	// XXX: Is this check reasonable? May strftime() return non-empty
+	// result for empty format?
+	if (length == 0) {
+		return unify_atom(q, term3, q->latest_context, strdup(""));
+	}
+
+	struct tm tm;
+	node *n = term_firstarg(term2); tm.tm_sec = get_word(n);
+	n = term_next(n); tm.tm_min = get_word(n);
+	n = term_next(n); tm.tm_hour = get_word(n);
+	n = term_next(n); tm.tm_mday = get_word(n);
+	n = term_next(n); tm.tm_mon = get_word(n);
+	n = term_next(n); tm.tm_year = get_word(n);
+	n = term_next(n); tm.tm_wday = get_word(n);
+	n = term_next(n); tm.tm_yday = get_word(n);
+	n = term_next(n); tm.tm_isdst = get_word(n);
+
+	char *buffer = NULL;
+	int tries = 0;
+	const int max_tries = 5;
+	while (++tries <= max_tries) {
+		// make enough space for some long formats, e.g. `%c'
+		length = 128 + length * 2;
+		char *buffer = realloc(buffer, length);
+
+		// FIXME: `0' returned by strftime() does not always indicate
+		// an error, seems there is no easy way to check that.
+		if (strftime(buffer, length, format, &tm) > 0) {
+			return unify_atom(q, term3, q->latest_context, buffer);
+		}
+	}
+
+	free(buffer);
+
+	// XXX: maybe raise an error?
+	return 0;
+}
+
+static int bif_posix_gmt_time_2(tpl_query *q)
+{
+	node *args = get_args(q);
+	node *term1 = get_int(term1);
+	node *term2 = get_var(term2);
+
+	time_t t = (time_t)term1->val_i;
+	struct tm tm;
+
+	if (gmtime_r(&t, &tm) == NULL) {
+		return 0;
+	} else {
+		node *tmp = make_compound();
+
+		term_append(tmp, make_const_atom("time"));
+		term_append(tmp, make_int(tm.tm_sec));
+		term_append(tmp, make_int(tm.tm_min));
+		term_append(tmp, make_int(tm.tm_hour));
+		term_append(tmp, make_int(tm.tm_mday));
+		term_append(tmp, make_int(tm.tm_mon));
+		term_append(tmp, make_int(tm.tm_year));
+		term_append(tmp, make_int(tm.tm_wday));
+		term_append(tmp, make_int(tm.tm_yday));
+		term_append(tmp, make_int(tm.tm_isdst));
+
+		unify(q, term2, term2_ctx, tmp, -1);
+
+		return 1;
+	}
+}
+
+static int bif_posix_local_time_2(tpl_query *q)
+{
+	node *args = get_args(q);
+	node *term1 = get_int(term1);
+	node *term2 = get_var(term2);
+
+	time_t t = (time_t)term1->val_i;
+	struct tm tm;
+
+	if (localtime_r(&t, &tm) == NULL) {
+		return 0;
+	} else {
+		node *tmp = make_compound();
+
+		term_append(tmp, make_const_atom("time"));
+		term_append(tmp, make_int(tm.tm_sec));
+		term_append(tmp, make_int(tm.tm_min));
+		term_append(tmp, make_int(tm.tm_hour));
+		term_append(tmp, make_int(tm.tm_mday));
+		term_append(tmp, make_int(tm.tm_mon));
+		term_append(tmp, make_int(tm.tm_year));
+		term_append(tmp, make_int(tm.tm_wday));
+		term_append(tmp, make_int(tm.tm_yday));
+		term_append(tmp, make_int(tm.tm_isdst));
+
+		unify(q, term2, term2_ctx, tmp, -1);
+
+		return 1;
+	}
+}
+
+// XXX: Is it desirable to also return corrected `tm'?
+static int bif_posix_make_time_2(tpl_query *q)
+{
+	node *args = get_args(q);
+	node *term1 = get_compound(term1);
+	node *term2 = get_var(term2);
+
+	if (strcmp(term_functor(term1), "time")) {
+		return 0;
+	}
+
+	struct tm tm;
+	node *n = term_firstarg(term1); tm.tm_sec = get_word(n);
+	n = term_next(n); tm.tm_min = get_word(n);
+	n = term_next(n); tm.tm_hour = get_word(n);
+	n = term_next(n); tm.tm_mday = get_word(n);
+	n = term_next(n); tm.tm_mon = get_word(n);
+	n = term_next(n); tm.tm_year = get_word(n);
+	n = term_next(n); tm.tm_wday = get_word(n);
+	n = term_next(n); tm.tm_yday = get_word(n);
+	n = term_next(n); tm.tm_isdst = get_word(n);
+
+	time_t t = mktime(&tm);
+
+	if (t == -1) {
+		return 0;
+	} else {
+		return unify_int(q, term2, q->latest_context, t);
+	}
+}
+
+// XXX: To be consistent with posix:format_time/3, order by arguments
+// is different from strptime(), is this choice reasonable?
+static int bif_posix_parse_time_3(tpl_query *q)
+{
+	node *args = get_args(q);
+	node *term1 = get_atom(term1);
+	node *term2 = get_atom(term2);
+	node *term3 = get_var(term3);
+
+	struct tm tm;
+
+	memset(&tm, 0, sizeof(struct tm));
+
+	if (strptime(VAL_S(term2), VAL_S(term1), &tm) == NULL) {
+		return 0;
+	} else {
+		node *tmp = make_compound();
+
+		term_append(tmp, make_const_atom("time"));
+		term_append(tmp, make_int(tm.tm_sec));
+		term_append(tmp, make_int(tm.tm_min));
+		term_append(tmp, make_int(tm.tm_hour));
+		term_append(tmp, make_int(tm.tm_mday));
+		term_append(tmp, make_int(tm.tm_mon));
+		term_append(tmp, make_int(tm.tm_year));
+		term_append(tmp, make_int(tm.tm_wday));
+		term_append(tmp, make_int(tm.tm_yday));
+		term_append(tmp, make_int(tm.tm_isdst));
+
+		unify(q, term3, term3_ctx, tmp, -1);
+
+		return 1;
+	}
+}
+
+static int bif_posix_time_1(tpl_query *q)
+{
+	node *args = get_args(q);
+	node *term1 = get_var(term1);
+
+	time_t t = time(NULL);
+
+	if (t == -1) {
+		return 0;
+	} else {
+		return unify_int(q, term1, q->latest_context, t);
+	}
+}
+
+void bifs_load_posix(void)
+{
+	DEFINE_BIF("posix:format_time", 3, bif_posix_format_time_3);
+	DEFINE_BIF("posix:gmt_time", 2, bif_posix_gmt_time_2);
+	DEFINE_BIF("posix:local_time", 2, bif_posix_local_time_2);
+	DEFINE_BIF("posix:make_time", 2, bif_posix_make_time_2);
+	DEFINE_BIF("posix:parse_time", 3, bif_posix_parse_time_3);
+	DEFINE_BIF("posix:time", 1, bif_posix_time_1);
+}

--- a/src/trealla.c
+++ b/src/trealla.c
@@ -1563,6 +1563,7 @@ trealla *trealla_create(const char *name)
 		bifs_load_http();
 		bifs_load_ws();
 		bifs_load_stomp();
+		bifs_load_posix();
 		uuid_seed(time(NULL));
 #endif
 	}
@@ -1586,6 +1587,7 @@ trealla *trealla_create(const char *name)
 	sl_set(&pl->mods, strdup("http"), NULL);
 	sl_set(&pl->mods, strdup("ws"), NULL);
 	sl_set(&pl->mods, strdup("linda"), NULL);
+	sl_set(&pl->mods, strdup("posix"), NULL);
 
 	pl->pid_guard = lock_create();
 	pl->dbs_guard = lock_create();


### PR DESCRIPTION
Trying to add some thin wrapper for POSIX date and time interfaces.

It is incomplete, notably some undecided point (see comments in the code), also `BSDmakefile` have not been updated.

Just want to have a review if there are any fundamental problems. I would like to add some other POSIX prediates if this way is acceptable.