### PR TITLE
Fix segmentation fault, as `term4` may be NULL

### DIFF
--- a/src/bifs_posix.c
+++ b/src/bifs_posix.c
@@ -250,7 +250,7 @@ static int bif_posix_spawn_3(tpl_query *q)
 	posix_spawn_file_actions_init(&file_actions);
 
 	l = term4;
-	while (is_list(l)) {
+	while (l && is_list(l)) {
 		node *head = term_firstarg(l);
 		node *option = subst(q, head, term4_ctx);
 


### PR DESCRIPTION
`term4` may be `NULL`, it will cause segmentation fault if passed to `is_list`.