### PR TITLE
Fix build for FreeBSD

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,6 +1,6 @@
 CFLAGS = -Isrc -O3 $(OPT) -Wall -D_DEFAULT_SOURCE -D_BSD_SOURCE
 CFLAGS += -I/usr/local/include
-LDFLAGS = -lm
+LDFLAGS = -L/usr/local/lib -lm
 
 OBJECTS_ISO = src/trealla.o src/parser.o src/bifs_iso.o src/jela.o \
 			src/list.o src/print.o src/skiplist.o src/skipbuck.o \

--- a/src/bifs_posix.c
+++ b/src/bifs_posix.c
@@ -2,6 +2,7 @@
 #include <sys/wait.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <spawn.h>
 #include <stdio.h>
 #include <time.h>


### PR DESCRIPTION
* Newer version OpenSSL is needed, which is avaiable in ports, and installed in to `/usr/local/lib`, so `-L` flag is needed
* `<signal.h>` is required to include `siginfo_t` type